### PR TITLE
Copy missing folderEntity.data property in createFolderTree function

### DIFF
--- a/module/journal-sync.js
+++ b/module/journal-sync.js
@@ -462,7 +462,7 @@ async function exportJournal(journalEntry, parentPath) {
 async function createFolderTree(dataset) {
     let hashTable = Object.create(null);
     let dataTree = [];
-    dataset.forEach(folderEntity => hashTable[folderEntity.id] = { ...folderEntity, childNodes: [] });
+    dataset.forEach(folderEntity => hashTable[folderEntity.id] = { ...folderEntity, data: folderEntity.data, childNodes: [] });
 
     dataset.forEach(folderEntity => {
         if (folderEntity.parent) {


### PR DESCRIPTION
The `data` property of FolderEntity is not Enumerable (anymore?) so while creating `hashTable`, the `data` property was not copied over. It's the issue because the script uses `folderEntity.data.name` later on to create directories named after folders. This allows to copy `data` property, so name is accessible later on. Now exporting on 0.8.9 version of FoundryVTT works.